### PR TITLE
fix puppet4 incompatible template usage for syslog entry

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@
 #   Optional. Path to log file
 #
 # [*syslog*]
-#   Optional. Boolean if to use syslog
+#   Optional. Boolean if to use syslog. Default to false.
 #
 # [*log_level*]
 #   Optional. One of Critical, Error, Warning, Notice, Connect, Info

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class tinyproxy::params {
   $stathost = undef
   $statfile = '/usr/share/tinyproxy/stats.html'
   $logfile = '/var/log/tinyproxy/tinyproxy.log'
-  $syslog = undef
+  $syslog = false
   $log_level = 'Info'
   $pidfile = '/var/run/tinyproxy/tinyproxy.pid'
   $xtinyproxy = undef

--- a/templates/tinyproxy.conf.erb
+++ b/templates/tinyproxy.conf.erb
@@ -99,8 +99,7 @@ StatFile "<%= @statfile %>"
 # option must not be enabled if the Logfile directive is being used.
 # These two directives are mutually exclusive.
 #
-<%- if @syslog != :undef && ![TrueClass,FalseClass].index(@syslog.class).nil?
-if @syslog == true -%>
+<%- if @syslog == true -%>
 Syslog On
 <%- elsif @syslog == false -%>
 Syslog Off
@@ -112,8 +111,7 @@ Syslog Off
 # exclusive.
 #
 Logfile "<%= @logfile %>"
-<%- end
-end -%>
+<%- end -%>
 
 #
 # LogLevel: 


### PR DESCRIPTION
- use default syslog value correponding to package default.
- remove incompatible statement
